### PR TITLE
TSeries.combine representation metadata fix

### DIFF
--- a/TSeries.m
+++ b/TSeries.m
@@ -1309,7 +1309,13 @@
       end
       if obj.tensorOrder==0
         Ts = TSeries(NewTime, dataTmp, 'tensorOrder', obj.tensorOrder);
-      else
+      elseif obj.tensorOrder==1
+        Ts = TSeries(NewTime, dataTmp, 'tensorOrder', obj.tensorOrder, ...
+          'tensorBasis', obj.BASIS{obj.tensorBasis_} , 'repres', obj.representation{1}); % Combined TSeries
+      elseif obj.tensorOrder==2
+        Ts = TSeries(NewTime, dataTmp, 'tensorOrder', obj.tensorOrder, ...
+          'tensorBasis', obj.BASIS{obj.tensorBasis_} , 'repres', obj.representation{1} , 'repres', obj.representation{2}); % Combined TSeries
+      else 
         Ts = TSeries(NewTime, dataTmp, 'tensorOrder', obj.tensorOrder, ...
           'tensorBasis', obj.BASIS{obj.tensorBasis_}); % Combined TSeries
       end


### PR DESCRIPTION
TSeries.combine fix to pass representation to output for tensorOrder=1 and 2. 
There is already a tensorbasis check so the two inputs should have the same representation. 
Empty representation for vectors and tensors causes problems later and is read-only.