### PR TITLE
Fix for single entry tensor

### DIFF
--- a/irf/+irf/ts_tensor_xyz.m
+++ b/irf/+irf/ts_tensor_xyz.m
@@ -9,4 +9,7 @@ if ~isa(time,'GenericTimeArray'), epoch = EpochTT(time);
 else, epoch = time;
 end
 
+% if only one entry (3x3) add singleton dimension to make first dim time (1x3x3)
+if ndims(data)==2; data_temp(1,:,:)=data; data=data_temp; end
+
 TS = TSeries(epoch,data,'tensor_xyz');


### PR DESCRIPTION
When constructing tensor with single entry, other scripts will pass data as a 2D array (3x3). TSeries expects a (nx3x3) array, checks length of 1st dimension (time) and returns an error. Fix reshapes data as a (1x3x3) array if time dimension is missing by adding a singleton dimension.