### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/-github-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/-github-bug-report.md
@@ -1,0 +1,42 @@
+---
+name: ".github/Bug report"
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+// TODO (you): please remove comments like this line and fill in this form as best you can, checking relevant boxes, etc.
+
+### Step 1: Latest code?
+- [ ] This issue is present in the most recent code (i.e. after running ```git pull``` this is still a problem).
+
+
+### Step 2: Describe your environment
+ * irfu-matlab branch (i.e. "master", "devel"): ____
+ * Matlab version used (i.e. "Matlab R2017a"): ____
+ * Operating system (ie "Windows 7", "Mac OS X 10.12.3", "Linux Ubuntu 16.04"): ____
+ - [ ] A 64-bit installation of Matlab was used.
+
+
+### Step 3: Describe the problem
+
+#### Expected behavior
+
+
+#### Actual behavior
+
+
+#### Steps to reproduce:
+  // TODO (you): describe how to reproduce the problem. (Or if you prefer: you can fill in the "Relevant code" section below).
+  1. _____
+  2. _____
+  3. _____
+
+#### Relevant code:
+
+  ```
+    // TODO (you): insert code here to reproduce the problem.
+    // (Or if you prefer: you can descbibe it in the "Steps to reproduce" section above).
+  ```

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+// TODO (you): please remove comments like this line and fill in this form as best you can, checking relevant boxes, etc.
+
+### Step 1: Latest code?
+- [ ] This issue is present in the most recent code (i.e. after running ```git pull``` this is still a problem).
+
+
+### Step 2: Describe your environment
+ * irfu-matlab branch (i.e. ``master``, ``devel``): ____
+ * Matlab version used (i.e. "Matlab R2020b"): ____
+ * Operating system (ie "Windows 10", "Mac OS X 10.15.6", "Linux Ubuntu 20.04"): ____
+ - [ ] A 64-bit installation of Matlab was used.
+
+
+### Step 3: Describe the problem
+
+#### Expected behavior
+
+
+#### Actual behavior
+
+
+#### Steps to reproduce:
+  // TODO (you): describe how to reproduce the problem. (Or if you prefer: you can fill in the "Relevant code" section below).
+  1. _____
+  2. _____
+  3. _____
+
+#### Relevant code:
+
+  ```
+    // TODO (you): insert code here to reproduce the problem.
+    // (Or if you prefer: you can describe it in the "Steps to reproduce" section above).
+  ```

--- a/.github/ISSUE_TEMPLATE/bug-reports.md
+++ b/.github/ISSUE_TEMPLATE/bug-reports.md
@@ -1,0 +1,42 @@
+---
+name: Bug reports
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+// TODO (you): please remove comments like this line and fill in this form as best you can, checking relevant boxes, etc.
+
+### Step 1: Latest code?
+- [ ] This issue is present in the most recent code (i.e. after running ```git pull``` this is still a problem).
+
+
+### Step 2: Describe your environment
+ * irfu-matlab branch (i.e. "master", "devel"): ____
+ * Matlab version used (i.e. "Matlab R2017a"): ____
+ * Operating system (ie "Windows 7", "Mac OS X 10.12.3", "Linux Ubuntu 16.04"): ____
+ - [ ] A 64-bit installation of Matlab was used.
+
+
+### Step 3: Describe the problem
+
+#### Expected behavior
+
+
+#### Actual behavior
+
+
+#### Steps to reproduce:
+  // TODO (you): describe how to reproduce the problem. (Or if you prefer: you can fill in the "Relevant code" section below).
+  1. _____
+  2. _____
+  3. _____
+
+#### Relevant code:
+
+  ```
+    // TODO (you): insert code here to reproduce the problem.
+    // (Or if you prefer: you can descbibe it in the "Steps to reproduce" section above).
+  ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+// TODO (you): please remove comments like this line and fill in this form as best you can, checking relevant boxes, etc.
+
+### Step 1: Latest code?
+- [ ] This issue is present in the most recent code (i.e. after running ```git pull``` this is still a problem).
+
+
+### Step 2: Describe your environment
+ * irfu-matlab branch (i.e. "master", "devel"): ____
+ * Matlab version used (i.e. "Matlab R2017a"): ____
+ * Operating system (ie "Windows 7", "Mac OS X 10.12.3", "Linux Ubuntu 16.04"): ____
+ - [ ] A 64-bit installation of Matlab was used.
+
+
+### Step 3: Describe the problem
+
+#### Expected behavior
+
+
+#### Actual behavior
+
+
+#### Steps to reproduce:
+  // TODO (you): describe how to reproduce the problem. (Or if you prefer: you can fill in the "Relevant code" section below).
+  1. _____
+  2. _____
+  3. _____
+
+#### Relevant code:
+
+  ```
+    // TODO (you): insert code here to reproduce the problem.
+    // (Or if you prefer: you can descbibe it in the "Steps to reproduce" section above).
+  ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Github has changed its approach to issue templates. 

Legacy: https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository

New: https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/about-issue-and-pull-request-templates